### PR TITLE
fix #8 - upgrade jts com.vividsolutions:jts:1.13 to org.locationtech.jts:jts-core:1.18.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+target

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jooq-postgis-spatial
         <customTypes>
             <customType>
                 <name>Geometry</name>
-                <type>com.vividsolutions.jts.geom.Geometry</type>
+                <type>org.locationtech.jts.geom.Geometry</type>
                 <binding>net.dmitry.jooq.postgis.spatial.binding.JTSGeometryBinding</binding>
             </customType>
         </customTypes>
@@ -29,7 +29,7 @@ jooq-postgis-spatial
         <customTypes>
             <customType>
                 <name>Geometry</name>
-                <type>com.vividsolutions.jts.geom.Geometry</type>
+                <type>org.locationtech.jts.geom.Geometry</type>
                 <binding>net.dmitry.jooq.postgis.spatial.binding.PostgisGeometryBinding</binding>
             </customType>
         </customTypes>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.vividsolutions</groupId>
-            <artifactId>jts</artifactId>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
             <version>${jts.version}</version>
             <exclusions>
                 <exclusion>
@@ -99,10 +99,10 @@
 
     <properties>
         <compileSource>1.8</compileSource>
-        <kotlin.version>1.0.0</kotlin.version>
+        <kotlin.version>1.5.21</kotlin.version>
         <postgresql.version>9.4-1201-jdbc4</postgresql.version>
         <jooq.version>3.7.3</jooq.version>
-        <jts.version>1.13</jts.version>
+        <jts.version>1.18.1</jts.version>
         <postgis-jdbc.version>2.2.0</postgis-jdbc.version>
     </properties>
 

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/EventLocator.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/EventLocator.java
@@ -20,10 +20,10 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinate.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinate.java
@@ -20,8 +20,8 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 
 /**
  * This coordinate class supports 4D coordinates, where the first 3 measures
@@ -33,7 +33,7 @@ import com.vividsolutions.jts.geom.CoordinateSequence;
  * substitute in the event that the Measure value is not used. In these cases
  * the Measure value shall simply be Double.NaN
  *
- * @see com.vividsolutions.jts.geom.Coordinate
+ * @see org.locationtech.jts.geom.Coordinate
  */
 public class MCoordinate extends Coordinate {
 	/**
@@ -159,7 +159,7 @@ public class MCoordinate extends Coordinate {
 	 * 
 	 * (non-Javadoc)
 	 * 
-	 * @see com.vividsolutions.jts.geom.Coordinate#equals(java.lang.Object)
+	 * @see org.locationtech.jts.geom.Coordinate#equals(java.lang.Object)
 	 */
 	public boolean equals(Object other) {
 		if (other instanceof Coordinate) {

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinateSequence.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinateSequence.java
@@ -20,9 +20,9 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 import java.io.Serializable;
 
@@ -99,7 +99,7 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getDimension()
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getDimension()
 	 */
 	public int getDimension() {
 		return 4;
@@ -110,15 +110,15 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getCoordinateCopy(int)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getCoordinateCopy(int)
 	 */
 	public Coordinate getCoordinateCopy(int index) {
 		return new Coordinate(coordinates[index]);
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getCoordinate(int,
-	 *	  com.vividsolutions.jts.geom.Coordinate)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getCoordinate(int,
+	 *	  org.locationtech.jts.geom.Coordinate)
 	 */
 	public void getCoordinate(int index, Coordinate coord) {
 		coord.x = coordinates[index].x;
@@ -126,14 +126,14 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getX(int)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getX(int)
 	 */
 	public double getX(int index) {
 		return coordinates[index].x;
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getY(int)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getY(int)
 	 */
 	public double getY(int index) {
 		return coordinates[index].y;
@@ -147,7 +147,7 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#getOrdinate(int, int)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#getOrdinate(int, int)
 	 */
 	public double getOrdinate(int index, int ordinateIndex) {
 		switch (ordinateIndex) {
@@ -164,7 +164,7 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	/**
-	 * @see com.vividsolutions.jts.geom.CoordinateSequence#setOrdinate(int, int, double)
+	 * @see org.locationtech.jts.geom.CoordinateSequence#setOrdinate(int, int, double)
 	 */
 	public void setOrdinate(int index, int ordinateIndex, double value) {
 		switch (ordinateIndex) {
@@ -186,6 +186,16 @@ public class MCoordinateSequence implements CoordinateSequence, Serializable {
 	}
 
 	public Object clone() {
+		MCoordinate[] cloneCoordinates = new MCoordinate[size()];
+		for (int i = 0; i < coordinates.length; i++) {
+			cloneCoordinates[i] = (MCoordinate) coordinates[i].clone();
+		}
+
+		return new MCoordinateSequence(cloneCoordinates);
+	}
+
+	@Override
+	public CoordinateSequence copy() {
 		MCoordinate[] cloneCoordinates = new MCoordinate[size()];
 		for (int i = 0; i < coordinates.length; i++) {
 			cloneCoordinates[i] = (MCoordinate) coordinates[i].clone();

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinateSequenceFactory.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MCoordinateSequenceFactory.java
@@ -20,9 +20,9 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
 
 import java.io.Serializable;
 
@@ -71,7 +71,7 @@ public class MCoordinateSequenceFactory implements CoordinateSequenceFactory,
 	 * Creates a MCoordinateSequence instance initialized to the size parameter.
 	 * Note that the dimension argument is ignored.
 	 *
-	 * @see com.vividsolutions.jts.geom.CoordinateSequenceFactory#create(int, int)
+	 * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(int, int)
 	 */
 	public CoordinateSequence create(int size, int dimension) {
 		return new MCoordinateSequence(size);

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MGeometry.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MGeometry.java
@@ -20,10 +20,10 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.io.Serializable;
 

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MGeometryFactory.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MGeometryFactory.java
@@ -20,15 +20,15 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
 
 /**
  * Extension of the GeometryFactory for constructing Geometries with Measure
  * support.
  *
- * @see com.vividsolutions.jts.geom.GeometryFactory
+ * @see org.locationtech.jts.geom.GeometryFactory
  */
 public class MGeometryFactory extends GeometryFactory {
 
@@ -64,7 +64,7 @@ public class MGeometryFactory extends GeometryFactory {
 	 *
 	 * @param coordinates array of MCoordinate defining this geometry's vertices
 	 * @return An instance of MLineString containing the coordinates
-	 * @see #createLineString(com.vividsolutions.jts.geom.Coordinate[])
+	 * @see #createLineString(org.locationtech.jts.geom.Coordinate[])
 	 */
 	public MLineString createMLineString(MCoordinate[] coordinates) {
 		return createMLineString(
@@ -89,7 +89,7 @@ public class MGeometryFactory extends GeometryFactory {
 	 *
 	 * @param coordinates a CoordinateSequence possibly empty, or null
 	 * @return An MLineString instance based on the <code>coordinates</code>
-	 * @see #createLineString(com.vividsolutions.jts.geom.CoordinateSequence)
+	 * @see #createLineString(org.locationtech.jts.geom.CoordinateSequence)
 	 */
 	public MLineString createMLineString(CoordinateSequence coordinates) {
 		return new MLineString(coordinates, this);

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MLineString.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MLineString.java
@@ -20,13 +20,13 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateArrays;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineSegment;
-import com.vividsolutions.jts.geom.LineString;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateArrays;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LineString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,8 +55,8 @@ public class MLineString extends LineString implements MGeometry {
 		determineMonotone();
 	}
 
-	public Object clone() {
-		LineString ls = (LineString) super.clone();
+	public MLineString copy() {
+		LineString ls = (LineString) super.copy();
 		return new MLineString(ls.getCoordinateSequence(), this.getFactory());
 	}
 
@@ -192,7 +192,7 @@ public class MLineString extends LineString implements MGeometry {
 	/*
 		  * (non-Javadoc)
 		  *
-		  * @see com.vividsolutions.jts.geom.Geometry#getGeometryType()
+		  * @see org.locationtech.jts.geom.Geometry#getGeometryType()
 		  */
 
 	public String getGeometryType() {
@@ -202,7 +202,7 @@ public class MLineString extends LineString implements MGeometry {
 	/*
 		  * (non-Javadoc)
 		  *
-		  * @see com.vividsolutions.jts.geom.Geometry#getMatCoordinate(com.vividsolutions.jts.geom.Coordinate,
+		  * @see org.locationtech.jts.geom.Geometry#getMatCoordinate(org.locationtech.jts.geom.Coordinate,
 		  *      double)
 		  */
 

--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MultiMLineString.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/mgeom/MultiMLineString.java
@@ -20,11 +20,11 @@
  */
 package net.dmitry.jooq.postgis.spatial.jts.mgeom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiLineString;
 
 public class MultiMLineString extends MultiLineString implements MGeometry {
 
@@ -140,7 +140,7 @@ public class MultiMLineString extends MultiLineString implements MGeometry {
 		double mval = Double.NaN;
 		double dist = Double.POSITIVE_INFINITY;
 
-		com.vividsolutions.jts.geom.Point p = this.getFactory().createPoint(co);
+		org.locationtech.jts.geom.Point p = this.getFactory().createPoint(co);
 
 		// find points within tolerance for getMatCoordinate
 		for (int i = 0; i < this.getNumGeometries(); i++) {
@@ -162,8 +162,8 @@ public class MultiMLineString extends MultiLineString implements MGeometry {
 		return mval;
 	}
 
-	public Object clone() {
-		MultiLineString ml = (MultiLineString) super.clone();
+	public MultiLineString copy() {
+		MultiLineString ml = (MultiLineString) super.copy();
 		return ml;
 	}
 

--- a/src/main/kotlin/net/dmitry/jooq/postgis/spatial/binding/JTSGeometryBinding.kt
+++ b/src/main/kotlin/net/dmitry/jooq/postgis/spatial/binding/JTSGeometryBinding.kt
@@ -1,6 +1,6 @@
 package net.dmitry.jooq.postgis.spatial.binding
 
-import com.vividsolutions.jts.geom.Geometry
+import org.locationtech.jts.geom.Geometry
 import net.dmitry.jooq.postgis.spatial.converter.JTSGeometryConverter
 import org.jooq.*
 import org.jooq.impl.DSL
@@ -11,20 +11,20 @@ import org.jooq.impl.DSL
  */
 class JTSGeometryBinding : Binding<Any, Geometry> {
 
-    private val geometryConverter = JTSGeometryConverter();
+    private val geometryConverter = JTSGeometryConverter()
 
-    override fun converter(): Converter<Any, Geometry>? = geometryConverter
+    override fun converter(): Converter<Any, Geometry> = geometryConverter
 
     override fun set(ctx: BindingSetStatementContext<Geometry>?) {
         ctx?.statement()?.setObject(ctx.index(), ctx.convert(converter()).value())
     }
 
     override fun get(ctx: BindingGetStatementContext<Geometry>?) {
-        ctx?.convert(converter())?.value(ctx.statement().getObject(ctx.index()));
+        ctx?.convert(converter())?.value(ctx.statement().getObject(ctx.index()))
     }
 
     override fun get(ctx: BindingGetResultSetContext<Geometry>?) {
-        ctx?.convert(converter())?.value(ctx.resultSet().getObject(ctx.index()));
+        ctx?.convert(converter())?.value(ctx.resultSet().getObject(ctx.index()))
     }
 
     override fun sql(ctx: BindingSQLContext<Geometry>?) {

--- a/src/test/kotlin/net/dmitry/jooq/postgis/spatial/converter/JTSGeometryConverterTest.kt
+++ b/src/test/kotlin/net/dmitry/jooq/postgis/spatial/converter/JTSGeometryConverterTest.kt
@@ -1,7 +1,7 @@
 package net.dmitry.jooq.postgis.spatial.converter
 
-import com.vividsolutions.jts.geom.Coordinate
-import com.vividsolutions.jts.geom.Geometry
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.Geometry
 import net.dmitry.jooq.postgis.spatial.jts.JTS
 import org.junit.Assert.assertTrue
 import org.junit.Test


### PR DESCRIPTION
This is a backward incompatible change.

Upgrade com.vividsolutions.jts to the new org.locationtech.jts
and artifact com.vividsolutions:jts:1.13 to org.locationtech.jts:jts-core:1.18.1.

Also upgrade Kotlin to latest 1.5.21.

Did some manual changes in:
JTSGeometryConverter and MCoordinateSequence to fix compilation and
warnings.
Replaced deprecated clone() with copy()