### PR TITLE
Allow to replace defaultGeomFactory

### DIFF
--- a/src/main/java/net/dmitry/jooq/postgis/spatial/jts/JTS.java
+++ b/src/main/java/net/dmitry/jooq/postgis/spatial/jts/JTS.java
@@ -41,4 +41,7 @@ public class JTS {
 		return defaultGeomFactory;
 	}
 
+	public static void setDefaultGeomFactory(MGeometryFactory defaultGeomFactory) {
+		this.defaultGeomFactory = defaultGeomFactory;
+	}
 }


### PR DESCRIPTION
This is needed in order to support the inner creation of geometric objects (by the lib) with srid 4326 and such.